### PR TITLE
fix: Java 8 でのテストが落ちていたので修正

### DIFF
--- a/src/test/java/nablarch/core/text/json/JavaTimeToJsonSerializerTest.java
+++ b/src/test/java/nablarch/core/text/json/JavaTimeToJsonSerializerTest.java
@@ -37,7 +37,7 @@ public class JavaTimeToJsonSerializerTest {
 
             @Override
             protected String getDatePattern(JsonSerializationSettings settings) {
-                return datePattern;
+                return JavaTimeToJsonSerializerTest.this.datePattern;
             }
 
             @Override


### PR DESCRIPTION
`datePattern` が、 `JavaTimeToJsonSerializer` のインスタンスフィールドを参照していて、 `JavaTimeToJsonSerializerTest` の `datePattern` を参照できていなかった。