### PR TITLE
fix: Java 14 で NPE のメッセージが詳細化された修正に影響を受けないように、独自のNPEをスローするように修正

### DIFF
--- a/src/main/java/nablarch/core/text/json/ObjectToJsonSerializer.java
+++ b/src/main/java/nablarch/core/text/json/ObjectToJsonSerializer.java
@@ -47,6 +47,9 @@ public class ObjectToJsonSerializer implements JsonSerializer {
      */
     @Override
     public void serialize(Writer writer, Object value) throws IOException {
+        if (value == null) {
+            throw new NullPointerException("value must not be null.");
+        }
         stringSerializer.serialize(writer, value.toString());
     }
 

--- a/src/test/java/nablarch/core/text/json/ObjectToJsonSerializerTest.java
+++ b/src/test/java/nablarch/core/text/json/ObjectToJsonSerializerTest.java
@@ -72,7 +72,7 @@ public class ObjectToJsonSerializerTest {
             }
         });
 
-        assertThat(e.getMessage(), is(nullValue()));
+        assertThat(e.getMessage(), is("value must not be null."));
     }
 
 }


### PR DESCRIPTION
https://news.mynavi.jp/techplus/article/imajava-17/
Java 14 までは、 null 参照による NPE はメッセージが空(null)でしたが、 Java 14 から親切なメッセージが設定されるようになりました。

この影響で、 JSON ログのテストで NPE のメッセージが null であることを検証しているテストが、 Java 17 でのテストで落ちてしまいます。

意図的な NPE であることを明確にするため、 NPE を独自に生成してメッセージを設定してスローするようにしました。

JSONログ対応を先に取り込みたいので、このリポジトリだけ優先して先に develop にマージさせたいです。