### PR TITLE
SonarQube警告対応

### DIFF
--- a/src/main/java/nablarch/core/text/json/JavaTimeToJsonSerializer.java
+++ b/src/main/java/nablarch/core/text/json/JavaTimeToJsonSerializer.java
@@ -64,11 +64,11 @@ public abstract class JavaTimeToJsonSerializer implements JsonSerializer {
      */
     private Object getFormatter(JsonSerializationSettings settings) {
         datePattern = getDatePattern(settings);
-        Object formatter = null;
+        Object dateTimeFormatter = null;
         try {
             Class<?> clazz = Class.forName("java.time.format.DateTimeFormatter");
             Method method = clazz.getDeclaredMethod("ofPattern", String.class);
-            formatter = method.invoke(null, datePattern);
+            dateTimeFormatter = method.invoke(null, datePattern);
         } catch (ClassNotFoundException e) {
             // (coverage) Java7以前の場合に通過する
             // NOOP この例外は想定の動作の為、何もしない
@@ -90,7 +90,7 @@ public abstract class JavaTimeToJsonSerializer implements JsonSerializer {
             throw new RuntimeException(e);
         }
 
-        return formatter;
+        return dateTimeFormatter;
     }
 
     /**
@@ -106,9 +106,9 @@ public abstract class JavaTimeToJsonSerializer implements JsonSerializer {
      * @return フォーマットメソッド
      */
     private Method getFormatMethod(Class<?> clazz) {
-        Method formatMethod;
+        Method dateFormatMethod;
         try {
-            formatMethod = clazz.getMethod("format", Class.forName("java.time.temporal.TemporalAccessor"));
+            dateFormatMethod = clazz.getMethod("format", Class.forName("java.time.temporal.TemporalAccessor"));
         } catch (ClassNotFoundException e) {
             // (coverage) 到達しえない例外
             // java.time.temporal.TemporalAccessor は
@@ -125,7 +125,7 @@ public abstract class JavaTimeToJsonSerializer implements JsonSerializer {
             throw new RuntimeException(e);
         }
 
-        return formatMethod;
+        return dateFormatMethod;
     }
 
     /**

--- a/src/main/java/nablarch/core/text/json/JavaTimeToJsonSerializer.java
+++ b/src/main/java/nablarch/core/text/json/JavaTimeToJsonSerializer.java
@@ -133,8 +133,18 @@ public abstract class JavaTimeToJsonSerializer implements JsonSerializer {
      */
     @Override
     public boolean isTarget(Class<?> valueClass) {
-        return formatMethod != null && valueClass.getName().equals(getValueClassName());
-        // (coverage) Java7以前の場合に formatMethod != null が成立する
+        if (formatMethod == null) {
+            // formatMethod が取得できないのは Java 7 以下で Date&Time API が存在しない環境なので
+            // 常に対象外と判定する
+            return false;
+        }
+
+        try {
+            final Class<?> supportedClass = Class.forName(getValueClassName());
+            return supportedClass.isAssignableFrom(valueClass);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/nablarch/core/text/json/MapToJsonSerializer.java
+++ b/src/main/java/nablarch/core/text/json/MapToJsonSerializer.java
@@ -89,25 +89,63 @@ public class MapToJsonSerializer implements JsonSerializer {
     @Override
     public void serialize(Writer writer, Object value) throws IOException {
         Map<?, ?> map = (Map<?, ?>) value;
-        boolean isFirst = true;
+        boolean first = true;
         writer.append(BEGIN_OBJECT);
         for (Map.Entry<?, ?> member: map.entrySet()) {
-            Object memberName = member.getKey();
-            if (memberName != null && memberNameSerializer.isTarget(memberName.getClass())) {
-                Object memberValue = member.getValue();
-                if (memberValue != null || !isIgnoreNullValueMember) {
-                    if (!isFirst) {
-                        writer.append(VALUE_SEPARATOR);
-                    } else {
-                        isFirst = false;
-                    }
-                    memberNameSerializer.serialize(writer, memberName);
-                    writer.append(NAME_SEPARATOR);
-                    manager.getSerializer(memberValue).serialize(writer, memberValue);
-                }
+            if (isSkip(member)) {
+                continue;
             }
+
+            if (!first) {
+                writer.append(VALUE_SEPARATOR);
+            }
+
+            writeMember(writer, member);
+
+            first = false;
         }
         writer.append(END_OBJECT);
+    }
+
+    /**
+     * メンバーの情報を JSON 形式にフォーマットして Writer に書き出す。
+     * @param writer 出力先の Writer
+     * @param member 出力するメンバー
+     * @throws IOException 出力時にエラーが発生した場合
+     */
+    protected void writeMember(Writer writer, Map.Entry<?, ?> member) throws IOException {
+        memberNameSerializer.serialize(writer, member.getKey());
+        writer.append(NAME_SEPARATOR);
+        Object memberValue = member.getValue();
+        manager.getSerializer(memberValue).serialize(writer, memberValue);
+    }
+
+    /**
+     * 指定されたメンバーが出力の条件を満たしていないことを判定する。
+     * @param member 判定対象のメンバー
+     * @return 出力の条件を満たしていない場合は true
+     */
+    protected boolean isSkip(Map.Entry<?, ?> member) {
+        return isNotSupportedMemberName(member.getKey())
+                || isNotSupportedMemberValue(member.getValue());
+    }
+
+    /**
+     * メンバーの名前が出力サポート対象か判定する。
+     * @param memberName メンバーの名前
+     * @return 出力サポート対象の場合は true
+     */
+    protected boolean isNotSupportedMemberName(Object memberName) {
+        return memberName == null || !memberNameSerializer.isTarget(memberName.getClass());
+    }
+
+    /**
+     * メンバーの値が出力がサポートされていない値かどうか判定する。
+     * @param memberValue メンバーの値
+     * @return 出力がサポートされていない値の場合は true
+     */
+    protected boolean isNotSupportedMemberValue(Object memberValue) {
+        return memberValue == null && isIgnoreNullValueMember;
     }
 
 }

--- a/src/main/java/nablarch/core/text/json/MapToJsonSerializer.java
+++ b/src/main/java/nablarch/core/text/json/MapToJsonSerializer.java
@@ -91,9 +91,10 @@ public class MapToJsonSerializer implements JsonSerializer {
         Map<?, ?> map = (Map<?, ?>) value;
         boolean isFirst = true;
         writer.append(BEGIN_OBJECT);
-        for (Object memberName: map.keySet()) {
+        for (Map.Entry<?, ?> member: map.entrySet()) {
+            Object memberName = member.getKey();
             if (memberName != null && memberNameSerializer.isTarget(memberName.getClass())) {
-                Object memberValue = map.get(memberName);
+                Object memberValue = member.getValue();
                 if (memberValue != null || !isIgnoreNullValueMember) {
                     if (!isFirst) {
                         writer.append(VALUE_SEPARATOR);

--- a/src/main/java/nablarch/core/text/json/StringToJsonSerializer.java
+++ b/src/main/java/nablarch/core/text/json/StringToJsonSerializer.java
@@ -71,59 +71,55 @@ public class StringToJsonSerializer implements JsonSerializer {
             return;
         }
 
-        int pos;
-        char c;
-        int len = s.length();
-        boolean needEscape = false;
-        String hexValue;
-
-        for (pos = 0; pos < len; pos++) {
-            c = s.charAt(pos);
-            if (c < 0x20 || c == 0x22 || c == 0x5c) {
-                needEscape = true;
-                break;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (needsEscape(c)) {
+                writer.append(escape(c));
+            } else {
+                writer.append(c);
             }
         }
-        if (needEscape) {
-            int start = 0;
-            for (; pos < len; pos++) {
-                c = s.charAt(pos);
-                if (c < 0x20 || c == '\\' || c == '"') {
-                    if (start != pos) {
-                        writer.append(s, start, pos);
-                    }
-                    switch (c) {
-                        case '\\':
-                        case '"':
-                            writer.append('\\').append(c);
-                            break;
-                        case '\b':
-                            writer.append("\\b");
-                            break;
-                        case '\f':
-                            writer.append("\\f");
-                            break;
-                        case '\n':
-                            writer.append("\\n");
-                            break;
-                        case '\r':
-                            writer.append("\\r");
-                            break;
-                        case '\t':
-                            writer.append("\\t");
-                            break;
-                        default:
-                            hexValue = "000" + Integer.toHexString(c);
-                            writer.append("\\u").append(hexValue,hexValue.length() - 4, hexValue.length());
-                    }
-                    start = pos + 1;
-                }
-            }
-            if (start != pos) {
-                writer.append(s, start, pos);
-            }
-        } else {
-            writer.append(s);
+    }
+
+    /**
+     * 指定された文字が、エスケープが必要な文字かどうか判定する。
+     * <p>
+     * 以下のいずれかの文字が、エスケープが必要な文字に該当する。
+     * <ul>
+     *   <li>制御文字 (ASCIIコード上、半角スペースより前の文字)</li>
+     *   <li>バックスラッシュ ('\')</li>
+     *   <li>ダブルクォーテーション ('"')</li>
+     * </ul>
+     * </p>
+     * @param c 判定対象の文字
+     * @return エスケープが必要な場合は true
+     */
+    private boolean needsEscape(char c) {
+        return c < ' ' || c == '\\' || c == '"';
+    }
+
+    /**
+     * 指定された文字をエスケープする。
+     * @param c エスケープ対象の文字
+     * @return エスケープ後の文字列
+     */
+    private String escape(char c) {
+        switch (c) {
+            case '\\':
+            case '"':
+                return "\\" + c;
+            case '\b':
+                return "\\b";
+            case '\f':
+                return "\\f";
+            case '\n':
+                return "\\n";
+            case '\r':
+                return "\\r";
+            case '\t':
+                return "\\t";
+            default:
+                return String.format("\\u%04x", (int)c);
         }
     }
 }


### PR DESCRIPTION
構造化ログのコードで SonarQube から静的解析の Major 以上の警告がでた箇所の修正。

MapToJsonSerializer については、メソッドの複雑さの警告は出ていませんでしたが、サブクラスの AppLogMapToJsonSerialzier(nablarch-core-applog) の警告対応でリファクタリングした結果をフィードバックすることで実装をより簡潔にできると思ったので修正しています。
> https://github.com/nablarch/nablarch-core/commit/f4eacab68c5a602c453d75fa810f3c91588e0fec