### PR TITLE
TransactionEventCallbackを公開API化しました

### DIFF
--- a/src/main/java/nablarch/fw/TransactionEventCallback.java
+++ b/src/main/java/nablarch/fw/TransactionEventCallback.java
@@ -1,5 +1,7 @@
 package nablarch.fw;
 
+import nablarch.core.util.annotation.Published;
+
 import java.util.List;
 
 /**
@@ -10,6 +12,7 @@ import java.util.List;
  * @param <TData>ハンドラへの入力データ
  * @author hisaaki sioiri
  */
+@Published(tag = "architect")
 public interface TransactionEventCallback<TData> {
 
     /** リクエストデータを示すキー */

--- a/src/main/java/nablarch/fw/TransactionEventCallback.java
+++ b/src/main/java/nablarch/fw/TransactionEventCallback.java
@@ -41,7 +41,7 @@ public interface TransactionEventCallback<TData> {
      * 
      * @param <TData> ハンドラの入力データの型
      */
-    public abstract static class Provider<TData> {        
+    abstract class Provider<TData> {
         /**
          * ハンドラキューの内容を走査し、
          * {@link TransactionEventCallback}を実装した後続ハンドラを返す。

--- a/src/test/java/nablarch/core/ThreadContextTest.java
+++ b/src/test/java/nablarch/core/ThreadContextTest.java
@@ -12,7 +12,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**

--- a/src/test/java/nablarch/core/text/json/ObjectToJsonSerializerTest.java
+++ b/src/test/java/nablarch/core/text/json/ObjectToJsonSerializerTest.java
@@ -10,7 +10,6 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;

--- a/src/test/java/nablarch/core/util/DateUtilTest.java
+++ b/src/test/java/nablarch/core/util/DateUtilTest.java
@@ -17,7 +17,6 @@ import org.hamcrest.CoreMatchers;
 
 import nablarch.core.ThreadContext;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/nablarch/core/util/FilePathSettingTest.java
+++ b/src/test/java/nablarch/core/util/FilePathSettingTest.java
@@ -13,7 +13,6 @@ import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/nablarch/core/util/I18NUtilTest.java
+++ b/src/test/java/nablarch/core/util/I18NUtilTest.java
@@ -16,7 +16,6 @@ import org.hamcrest.CoreMatchers;
 
 import nablarch.core.ThreadContext;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 

--- a/src/test/java/nablarch/core/util/map/CaseInsensitiveMapTest.java
+++ b/src/test/java/nablarch/core/util/map/CaseInsensitiveMapTest.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CaseInsensitiveMapTest {

--- a/src/test/java/nablarch/core/util/map/MultipleKeyCaseMapTest.java
+++ b/src/test/java/nablarch/core/util/map/MultipleKeyCaseMapTest.java
@@ -10,7 +10,6 @@ import org.hamcrest.CoreMatchers;
 
 import nablarch.core.util.StringUtil;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
[解説書](https://nablarch.github.io/docs/5u24/doc/application_framework/application_framework/handlers/common/transaction_management_handler.html#id8)には`TransactionEventCallback`の実装例が記載されているにもかかわらず、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。