### PR TITLE
Base64UtilのJavadocを修正

### DIFF
--- a/src/main/java/nablarch/core/util/Base64Util.java
+++ b/src/main/java/nablarch/core/util/Base64Util.java
@@ -7,7 +7,10 @@ import nablarch.core.util.annotation.Published;
 
 /**
  * Base64エンコーディングを行うユーティリティクラス。
- * 
+ * <p>
+ * 本クラスは、<a href="https://www.ietf.org/rfc/rfc4648.txt">RFC4648</a>に準拠したBase64エンコーディングを行う。
+ * エンコード及びデコード操作には、RFC4648の表1に記載されたBase64アルファベットを使用する。
+ *
  * @author Kiyohito Itoh
  */
 @Published(tag = "architect")
@@ -42,7 +45,8 @@ public final class Base64Util {
      * バイト配列をBase64でエンコードする。
      * <p/>
      * 引数にnullが渡された場合、nullを返す。<br/>
-     * 引数の長さが0の場合、空文字を返す。
+     * 引数の長さが0の場合、空文字を返す。 <br/>
+     * 本メソッドは、エンコード結果に改行文字を追加しない。
      * 
      * @param b バイト配列
      * @return エンコード結果の文字列

--- a/src/main/java/nablarch/core/util/Base64Util.java
+++ b/src/main/java/nablarch/core/util/Base64Util.java
@@ -1,6 +1,7 @@
 package nablarch.core.util;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 import java.util.StringTokenizer;
 
 import nablarch.core.util.annotation.Published;
@@ -29,9 +30,7 @@ public final class Base64Util {
     private static final byte[] DECODING = new byte[124];
     
     static {
-        for (int i = 0; i < DECODING.length; i++) {
-            DECODING[i] = 0x00;
-        }
+        Arrays.fill(DECODING, (byte) 0x00);
         for (int i = 0; i < ENCODING.length; i++) {
             DECODING[ENCODING[i]] = (byte) i;
         }
@@ -105,7 +104,7 @@ public final class Base64Util {
         if (base64 == null) {
             return null;
         }
-        if (base64.length() == 0) {
+        if (base64.isEmpty()) {
             return new byte[0];
         }
         
@@ -115,7 +114,7 @@ public final class Base64Util {
                 String.format("length of base64 was invalid. base64 = [%s], length = [%s]", base64, length));
         }
         
-        if (base64.substring(0, length - 2).indexOf("=") != -1
+        if (base64.substring(0, length - 2).contains("=")
                 || ('=' == base64.charAt(length - 2) && '=' != base64.charAt(length - 1))) {
             throw new IllegalArgumentException(
                     String.format("position of '=' in base64 was invalid. base64 = [%s]", base64));
@@ -137,11 +136,11 @@ public final class Base64Util {
             
             byte b1 = DECODING[c1];
             
-            byte b2 = 0x00;
+            byte b2;
             b2 = DECODING[c2];
             baos.write((byte) ((b1 & 0x3F) << 2 | (b2 >>> 4) & 0x03));
             
-            byte b3 = 0x00;
+            byte b3;
             if (c3 != '=') {
                 b3 = DECODING[c3];
                 baos.write((byte) ((b2 & 0x0F) << 4 | (b3 >>> 2) & 0x0F));

--- a/src/main/java/nablarch/core/util/Base64Util.java
+++ b/src/main/java/nablarch/core/util/Base64Util.java
@@ -137,9 +137,7 @@ public final class Base64Util {
             char c4 = base64.charAt(i++);
             
             byte b1 = DECODING[c1];
-            
-            byte b2;
-            b2 = DECODING[c2];
+            byte b2 = DECODING[c2];
             baos.write((byte) ((b1 & 0x3F) << 2 | (b2 >>> 4) & 0x03));
             
             byte b3;

--- a/src/main/java/nablarch/core/util/Base64Util.java
+++ b/src/main/java/nablarch/core/util/Base64Util.java
@@ -10,8 +10,7 @@ import nablarch.core.util.annotation.Published;
 /**
  * Base64エンコーディングを行うユーティリティクラス。
  * <p>
- * 本クラスは、<a href="https://www.ietf.org/rfc/rfc4648.txt">RFC4648</a>に準拠したBase64エンコーディングを行う。
- * エンコード及びデコード操作には、RFC4648の表1に記載されたBase64アルファベットを使用する。
+ * 本クラスは、<a href="https://www.ietf.org/rfc/rfc4648.txt">RFC4648</a>の「4. Base 64 Encoding」に準拠したBase64エンコーディングを行う。
  * <p>
  * Java8以降は、標準APIの{@link Base64#getEncoder()}及び{@link Base64#getDecoder()}で取得するエンコーダ・デコーダが本クラスと同等のBase64エンコーディング機能を提供しており、本クラスは後方互換のために存在している。
  *

--- a/src/main/java/nablarch/core/util/Base64Util.java
+++ b/src/main/java/nablarch/core/util/Base64Util.java
@@ -2,7 +2,6 @@ package nablarch.core.util;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.StringTokenizer;
 
 import nablarch.core.util.annotation.Published;
@@ -12,7 +11,7 @@ import nablarch.core.util.annotation.Published;
  * <p>
  * 本クラスは、<a href="https://www.ietf.org/rfc/rfc4648.txt">RFC4648</a>の「4. Base 64 Encoding」に準拠したBase64エンコーディングを行う。
  * <p>
- * Java8以降は、標準APIの{@link Base64#getEncoder()}及び{@link Base64#getDecoder()}で取得するエンコーダ・デコーダが本クラスと同等のBase64エンコーディング機能を提供しており、本クラスは後方互換のために存在している。
+ * Java8以降は、標準APIの{@link java.util.Base64#getEncoder()}及び{@link java.util.Base64#getDecoder()}で取得するエンコーダ・デコーダが本クラスと同等のBase64エンコーディング機能を提供しており、本クラスは後方互換のために存在している。
  *
  * @author Kiyohito Itoh
  */

--- a/src/main/java/nablarch/core/util/Base64Util.java
+++ b/src/main/java/nablarch/core/util/Base64Util.java
@@ -2,6 +2,7 @@ package nablarch.core.util;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.StringTokenizer;
 
 import nablarch.core.util.annotation.Published;
@@ -12,7 +13,7 @@ import nablarch.core.util.annotation.Published;
  * 本クラスは、<a href="https://www.ietf.org/rfc/rfc4648.txt">RFC4648</a>に準拠したBase64エンコーディングを行う。
  * エンコード及びデコード操作には、RFC4648の表1に記載されたBase64アルファベットを使用する。
  * <p>
- * Java8以降は、標準APIの{@link java.util.Base64}がBase64エンコーディングをサポートしており、本クラスは後方互換のために提供されている。
+ * Java8以降は、標準APIの{@link Base64#getEncoder()}及び{@link Base64#getDecoder()}で取得するエンコーダ・デコーダが本クラスと同等のBase64エンコーディング機能を提供しており、本クラスは後方互換のために存在している。
  *
  * @author Kiyohito Itoh
  */

--- a/src/main/java/nablarch/core/util/Base64Util.java
+++ b/src/main/java/nablarch/core/util/Base64Util.java
@@ -11,6 +11,8 @@ import nablarch.core.util.annotation.Published;
  * <p>
  * 本クラスは、<a href="https://www.ietf.org/rfc/rfc4648.txt">RFC4648</a>に準拠したBase64エンコーディングを行う。
  * エンコード及びデコード操作には、RFC4648の表1に記載されたBase64アルファベットを使用する。
+ * <p>
+ * Java8以降は、標準APIの{@link java.util.Base64}がBase64エンコーディングをサポートしており、本クラスは後方互換のために提供されている。
  *
  * @author Kiyohito Itoh
  */


### PR DESCRIPTION
# 修正内容

`Base64Util` のJavadocに、以下の内容を記載した。

- RFC4648に準拠したBase64エンコーディングを実施すること
- 後方互換のために提供されていること

また、合わせてインスペクションの警告にも対応した。
修正後自動テストを実行し、エラーが出ていないことを確認済み。